### PR TITLE
Fix windows header case

### DIFF
--- a/SpaceMarineCoreFix/dllmain.cpp
+++ b/SpaceMarineCoreFix/dllmain.cpp
@@ -1,6 +1,6 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 #include <detours.h>
 #include <string_view>
 


### PR DESCRIPTION
## Summary
- fix case of Windows header include to support case-sensitive filesystems

## Testing
- `cppcheck SpaceMarineCoreFix/dllmain.cpp`
- `x86_64-w64-mingw32-g++ -c SpaceMarineCoreFix/dllmain.cpp -I/usr/x86_64-w64-mingw32/include -o dllmain.o` *(fails: fatal error: detours.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844055c565083309465cd8807ad0f5c